### PR TITLE
Fix window blur desync when Cinnamon repositions new windows

### DIFF
--- a/BlurCinnamon@klangman/6.0/extension.js
+++ b/BlurCinnamon@klangman/6.0/extension.js
@@ -2477,6 +2477,10 @@ class BlurApplications extends BlurBase {
       //signalManager.connect(metaWindow, "unmanaged"/*"unmanaging"*/, () => this._unblurWindow(compositor) );
       signalManager.connect(compositor, "destroy", () => this._unblurWindow(compositor) );
       signalManager.connect(compositor, "notify::allocation", () => this._setClip(compositor) );
+      // Some windows are positioned after their first allocation, so keep the blur aligned
+      // when either the compositor actor or the MetaWindow reports a position update.
+      signalManager.connect(compositor, "position-changed", () => this._setClip(compositor) );
+      signalManager.connect(metaWindow, "position-changed", () => this._setClip(compositor) );
       //signalManager.connect(metaWindow, "notify::maximized-horizontally", () => this._setClip(compositor) );
       //signalManager.connect(metaWindow, "notify::maximized-vertically", () => this._setClip(compositor) );
 
@@ -2535,10 +2539,11 @@ class BlurApplications extends BlurBase {
          //let windowShadowSizeY = (compositor.get_height() - rect.height) / 2;
          //data.background.set_position( -rect.x+windowShadowSizeX, -rect.y+windowShadowSizeY );
 
-         // Set the background position to the displays 0,0 based on it's transformed position and it's current position
-         let [rx,ry] = data.background.get_transformed_position();
-         let [x,y] = data.background.get_position();
-         data.background.set_position( x-rx, y-ry );
+         // The blur background lives inside the window compositor actor, so it must be
+         // offset by the compositor's transformed stage position, not by its own previous
+         // transformed position. Otherwise the blur and the real window can drift apart.
+         let [rx, ry] = compositor.get_transformed_position();
+         data.background.set_position(-rx, -ry);
 
          let cornerEffect = this._getCornerEffect(data.background);
          if (cornerEffect) {
@@ -2728,6 +2733,8 @@ class BlurFocusEffect extends BlurBase {
       this._focusedCompositor = window.get_compositor_private();
       this._focusedCompositor.insert_child_at_index(this._background, 0);
       this._signalManager.connect(this._focusedCompositor, "notify::allocation", () => this._setClip() );
+      this._signalManager.connect(this._focusedCompositor, "position-changed", () => this._setClip() );
+      this._signalManager.connect(window, "position-changed", () => this._setClip() );
       this._signalManager.connect(window, "unmanaging", () => this._removeEffect() );
       this._focusedCompositor._blurCinnamonDataFocusEffect = { effectThis: this };
       this._setClip();
@@ -2738,6 +2745,8 @@ class BlurFocusEffect extends BlurBase {
       this._background.hide();
       if (this._focusedCompositor) {
          this._signalManager.disconnect("notify::allocation", this._focusedCompositor );
+         this._signalManager.disconnect("position-changed", this._focusedCompositor );
+         this._signalManager.disconnect("position-changed", this._focusedWindow );
          this._signalManager.disconnect("unmanaging", this._focusedWindow );
          this._focusedCompositor.remove_child(this._background);
          this._focusedCompositor._blurCinnamonDataFocusEffect = undefined;
@@ -2763,10 +2772,9 @@ class BlurFocusEffect extends BlurBase {
          //let windowShadowSizeY = (compositor.get_height() - rect.height) / 2;
          //data.background.set_position( -rect.x+windowShadowSizeX, -rect.y+windowShadowSizeY );
 
-         // Set the background position to the displays 0,0 based on it's transformed position and it's current position
-         let [rx,ry] = this._background.get_transformed_position();
-         let [x,y] = this._background.get_position();
-         this._background.set_position( x-rx, y-ry );
+         // Keep the focus background aligned with the compositor actor in stage coordinates.
+         let [rx, ry] = this._focusedCompositor.get_transformed_position();
+         this._background.set_position(-rx, -ry);
 
          if (this._cornerEffect)
             this._cornerEffect.clip = [rect.x+2, rect.y+2, rect.width-3, rect.height-3];


### PR DESCRIPTION
# Fix window blur desync on first window open

I was seeing a weird issue with blurred application windows on Cinnamon.

When opening some apps for the first time, like Terminal or Nemo, the real window and the blur actor could end up offset from each other. Visually it looked like there were two windows slightly separated. In practice, input also felt offset, because clicks and dragging only worked where the blur actor was, not where the visible window appeared to be.

What seems to happen is that Cinnamon can still reposition a window after the first allocation, but Blur Cinnamon was only updating the blur geometry on `notify::allocation`.

This patch makes the blur update on `position-changed` as well, both for the compositor actor and the `MetaWindow`.

It also changes the alignment logic to use the compositor actor's transformed position directly, instead of reusing the blur actor's own transformed position. That keeps the blur background aligned with the real window when Cinnamon moves it during the initial open.

I applied the same logic to the focused window blur effect too.

<img width="1029" height="669" alt="image" src="https://github.com/user-attachments/assets/fcf1dba4-a170-44eb-9637-043675aaf3b9" />
<img width="1100" height="802" alt="image" src="https://github.com/user-attachments/assets/81cea729-03fb-4125-9595-a69ba54f8418" />
