### PR TITLE
Fix OSD blur rendering and compatibility across Cinnamon versions

### DIFF
--- a/BlurCinnamon@klangman/6.0/extension.js
+++ b/BlurCinnamon@klangman/6.0/extension.js
@@ -1357,8 +1357,47 @@ class BlurOSD extends BlurBase {
 
    _show(...params) {
       let ret = blurOSDThis.original_show.call(this, ...params);
+      if (!usesWorkspaceOsd) {
+        let child =
+          this.actor
+            ? this.actor.get_first_child()
+            : null;
+
+        if (this.actor) {
+          log(
+            `[BlurOSD] OsdWindow actor: ` +
+            `${this.actor.width}x${this.actor.height} ` +
+            `class=${this.actor.get_style_class_name()}`
+          );
+        }
+
+        if (this._hbox) {
+          log(
+            `[BlurOSD] OsdWindow hbox: ` +
+            `${this._hbox.width}x${this._hbox.height} ` +
+            `class=${this._hbox.get_style_class_name()}`
+          );
+        }
+
+        if (child) {
+          log(
+            `[BlurOSD] OsdWindow child: ` +
+            `${child.width}x${child.height} ` +
+            `class=${child.get_style_class_name()}`
+          );
+        }
+      }
       if (settings.osdSliderEffects) {
-         try { blurOSDThis._showBackground(this, this._hbox || (this.actor ? this.actor.get_first_child() : null), false); } catch (e) { global.logError(e); }
+         try {
+            let actor = this._hbox || (this.actor ? this.actor.get_first_child() : null);
+            // On older Cinnamon versions the content actor may only
+            // cover the inner contents of the OSD, while this.actor
+            // represents the entire popup
+            let clipActor = (!usesWorkspaceOsd && this.actor) ? this.actor : actor;
+            blurOSDThis._showBackground(this, actor, false, clipActor);
+         } catch (e) {
+            global.logError(e);
+         }
       }
       return ret;
    }
@@ -1388,21 +1427,6 @@ class BlurOSD extends BlurBase {
 
    _infoOSD_show(...params) {
       let ret = blurOSDThis.original_infoOSD_show.call(this, ...params);
-      let child = this.actor ? this.actor.get_first_child() : null;
-      if (this.actor) {
-         log(
-            `[BlurOSD] InfoOSD actor: ` +
-            `${this.actor.width}x${this.actor.height} ` +
-            `class=${this.actor.get_style_class_name()}`
-         );
-      }
-      if (child) {
-         log(
-            `[BlurOSD] InfoOSD child: ` +
-            `${child.width}x${child.height} ` +
-            `class=${child.get_style_class_name()}`
-         );
-      }
       if (settings.osdWorkspaceEffects) {
          try {
             let actor = this.actor ? this.actor.get_first_child() : null;
@@ -1549,14 +1573,14 @@ class BlurOSD extends BlurBase {
          this._createDynamicEffect(this._background);
       }
    
-      let themeNode = actor.get_theme_node();
+      let radiusActor = clipActor || actor;
+      let themeNode = radiusActor.get_theme_node();
    
       if (themeNode) {
-         let corner_radius =
-            themeNode.get_border_radius(St.Corner.TOPLEFT);
+         let corner_radius = themeNode.get_border_radius(St.Corner.TOPLEFT);
    
          if (corner_radius === 9999) {
-            corner_radius = actor.height / 2;
+            corner_radius = radiusActor / 2;
          }
    
          this._updateCornerRadius(this._background, corner_radius / global.ui_scale);

--- a/BlurCinnamon@klangman/6.0/extension.js
+++ b/BlurCinnamon@klangman/6.0/extension.js
@@ -1388,8 +1388,29 @@ class BlurOSD extends BlurBase {
 
    _infoOSD_show(...params) {
       let ret = blurOSDThis.original_infoOSD_show.call(this, ...params);
+      let child = this.actor ? this.actor.get_first_child() : null;
+      if (this.actor) {
+         log(
+            `[BlurOSD] InfoOSD actor: ` +
+            `${this.actor.width}x${this.actor.height} ` +
+            `class=${this.actor.get_style_class_name()}`
+         );
+      }
+      if (child) {
+         log(
+            `[BlurOSD] InfoOSD child: ` +
+            `${child.width}x${child.height} ` +
+            `class=${child.get_style_class_name()}`
+         );
+      }
       if (settings.osdWorkspaceEffects) {
-         try { blurOSDThis._showBackground(this, this.actor ? this.actor.get_first_child() : null, true); } catch (e) { global.logError(e); }
+         try {
+            let actor = this.actor ? this.actor.get_first_child() : null;
+            let clipActor = this.actor || actor;
+            blurOSDThis._showBackground(this, actor, true, clipActor);
+         } catch (e) {
+            global.logError(e);
+         }
       }
       return ret;
    }
@@ -1422,7 +1443,6 @@ class BlurOSD extends BlurBase {
    
         this._setClip(actor);
         if (showBackground) background.show();
-   
         // Re-clip on the next idle cycle to catch layout shifts
         // after the first layout/paint cycle
         this._reclipIdleId = Mainloop.idle_add(() => {
@@ -1436,7 +1456,7 @@ class BlurOSD extends BlurBase {
       });
    }
 
-   _showBackground(osd, actor, isWorkspaceOsd = false) {
+   _showBackground(osd, actor, isWorkspaceOsd = false, clipActor = actor) {
       if (!actor)
          return;
       
@@ -1451,7 +1471,7 @@ class BlurOSD extends BlurBase {
         
          // Workspace OSD needs an explicit refresh because its visual
          // source changes when switching workspaces
-         this._scheduleReclip(actor, true);
+         this._scheduleReclip(clipActor, true);
    
          if ((this._blurType === BlurType.DynamicBlur ||
               this._blurType === BlurType.DynamicMC ||
@@ -1542,14 +1562,14 @@ class BlurOSD extends BlurBase {
          this._updateCornerRadius(this._background, corner_radius / global.ui_scale);
       }
    
-      if (osd.actor) {
-         this._signalManager.connect(osd.actor, "notify::allocation", () => this._setClip(actor));
+      if (osd.actor && osd.actor !== clipActor) {
+         this._signalManager.connect(osd.actor, "notify::allocation", () => this._setClip(clipActor));
       }
    
-      this._signalManager.connect(actor, "notify::allocation", () => this._setClip(actor));
+      this._signalManager.connect(clipActor, "notify::allocation", () => this._setClip(clipActor));
    
-      this._setClip(actor);
-      this._scheduleReclip(actor, true);
+      this._setClip(clipActor);
+      this._scheduleReclip(clipActor, true);
    }
 
    _hideBackground(osd, actor) {

--- a/BlurCinnamon@klangman/6.0/extension.js
+++ b/BlurCinnamon@klangman/6.0/extension.js
@@ -1357,36 +1357,6 @@ class BlurOSD extends BlurBase {
 
    _show(...params) {
       let ret = blurOSDThis.original_show.call(this, ...params);
-      if (!usesWorkspaceOsd) {
-        let child =
-          this.actor
-            ? this.actor.get_first_child()
-            : null;
-
-        if (this.actor) {
-          log(
-            `[BlurOSD] OsdWindow actor: ` +
-            `${this.actor.width}x${this.actor.height} ` +
-            `class=${this.actor.get_style_class_name()}`
-          );
-        }
-
-        if (this._hbox) {
-          log(
-            `[BlurOSD] OsdWindow hbox: ` +
-            `${this._hbox.width}x${this._hbox.height} ` +
-            `class=${this._hbox.get_style_class_name()}`
-          );
-        }
-
-        if (child) {
-          log(
-            `[BlurOSD] OsdWindow child: ` +
-            `${child.width}x${child.height} ` +
-            `class=${child.get_style_class_name()}`
-          );
-        }
-      }
       if (settings.osdSliderEffects) {
          try {
             let actor = this._hbox || (this.actor ? this.actor.get_first_child() : null);
@@ -1549,20 +1519,11 @@ class BlurOSD extends BlurBase {
          delete actor._blurCinnamonData;
       }
    
-      let [opacity, blendColor, blurType, radius, saturation] =
-         this._getSettings(settings.osdOverride);
+      let [opacity, blendColor, blurType, radius, saturation] = this._getSettings(settings.osdOverride);
    
       this._blurType = blurType;
    
-      this._background = this._createBackgroundAndEffects(
-         opacity,
-         blendColor,
-         blurType,
-         radius,
-         saturation,
-         global.overlay_group,
-         10
-      );
+      this._background = this._createBackgroundAndEffects(opacity, blendColor, blurType, radius, saturation, global.overlay_group, 10);
    
       this._background._blurCinnamonName = "OsdWindow";
       osd._blurCinnamonBackground = this._background;
@@ -1578,11 +1539,9 @@ class BlurOSD extends BlurBase {
    
       if (themeNode) {
          let corner_radius = themeNode.get_border_radius(St.Corner.TOPLEFT);
-   
          if (corner_radius === 9999) {
-            corner_radius = radiusActor / 2;
+            corner_radius = Math.min(radiusActor.width, radiusActor.height) / 2;
          }
-   
          this._updateCornerRadius(this._background, corner_radius / global.ui_scale);
       }
    
@@ -1636,6 +1595,7 @@ class BlurOSD extends BlurBase {
       super.destroy(this._background);
       this._background.destroy();
       this._background = null;
+      this.parent = null;
       if (osd) delete osd._blurCinnamonBackground;
      
       this._currentOsd = null;
@@ -1706,6 +1666,8 @@ class BlurOSD extends BlurBase {
       }
 
       this._hideBackground(this._currentOsd, this._currentActor);
+     
+      if (blurOSDThis === this) blurOSDThis = null;
    }
 }
 

--- a/BlurCinnamon@klangman/6.0/extension.js
+++ b/BlurCinnamon@klangman/6.0/extension.js
@@ -364,6 +364,16 @@ function clonePainted(background, actor) {
 }
 
 function createWindowClone(metaWindow, background, desktopOnly) {
+   if (background._blurCinnamonName === "OsdWindow") {
+      let activeWorkspace = global.workspace_manager.get_active_workspace();
+      if (!windowIsOnWorkspace(metaWindow, activeWorkspace)) {
+         debugMsg(
+            `Not cloning "${metaWindow.get_title()}" for OSD ` +
+            `because it is not on the active workspace`
+         );
+         return null;
+      }
+   }
    let owner = background._blurCinnamonMetaWindowOwner;
    if (background.is_mapped() && owner !== metaWindow && (!desktopOnly || metaWindow.get_window_type() === Meta.WindowType.DESKTOP) &&
       (!owner || owner.get_window_type() !== Meta.WindowType.DESKTOP || metaWindow.get_window_type() === Meta.WindowType.DESKTOP) ) {
@@ -485,6 +495,36 @@ function destroyAllNonDesktopClones(background) {
    }
 }
 
+function windowIsOnWorkspace(metaWindow, workspace) {
+    if (!metaWindow || !workspace)
+        return false;
+    
+    if (typeof metaWindow.located_on_workspace === 'function') {
+        try {
+            return metaWindow.located_on_workspace(workspace);
+        } catch (e) {
+            // Fall through to compatibility checks
+        }
+    }
+  
+    if (typeof metaWindow.is_on_all_workspaces === 'function') {
+        try {
+            if (metaWindow.is_on_all_workspaces())
+                return true;
+        } catch (e) {
+        }
+    }
+  
+    if (typeof metaWindow.get_workspace === 'function') {
+        try {
+            return metaWindow.get_workspace() === workspace;
+        } catch (e) {
+        }
+    }
+    // Return true to prevent the window from being excluded on an unsupported Cinnamon/Muffin version.
+    return true;
+}
+
 // This function just schedules an update to the background clones.
 // We don't do this work right away for a number of reasons:
 // 1. There are (what I believe to be) bugs in Clutter that causes hangs and weird behavior if done immediately
@@ -506,7 +546,8 @@ function cloneWindowsForBackgroundNow(background, desktopOnly) {
    if (!background._blurCinnamonWinClones) {
       return;
    }
-   let currentWs = global.workspace_manager.get_active_workspace_index();
+   let activeWorkspace = global.workspace_manager.get_active_workspace();
+   let filterByWorkspace = background._blurCinnamonName === "OsdWindow";
    let [blurX, blurY, blurWidth, blurHeight] = getBackgroundClip(background);
    if (blurWidth===0 || blurHeight===0 || !background.is_mapped()) {
       debugMsg( `Blurred background is zero size or unmapped: width ${blurWidth}  height ${blurHeight}  mapped ${background.is_mapped()}` );
@@ -521,18 +562,26 @@ function cloneWindowsForBackgroundNow(background, desktopOnly) {
    let windows = global.get_window_actors();
    windows.forEach( (window) => {
       let metaWindow = window.get_meta_window();
+      if (!metaWindow)
+          return;
+      
       let compositor = metaWindow.get_compositor_private();
-      if (metaWindow && compositor && compositor.visible && (!desktopOnly || metaWindow.get_window_type() === Meta.WindowType.DESKTOP) &&
-          metaWindow.get_window_type() !== Meta.WindowType.OVERRIDE_OTHER /*&& metaWindow.get_wm_class() !== "Nemo-desktop"*/)
-      {
-         let winRect = metaWindow.get_buffer_rect();
-         let winX = winRect.x;
-         let winY = winRect.y;
-         let winX2 = winRect.x + winRect.width;
-         let winY2 = winRect.y + winRect.height;
-         if (rectOverlap(winX, winY, winX2, winY2, blurX, blurY, blurX2, blurY2)) {
-            windowsToClone.push(metaWindow);
-         }
+      if (!compositor)
+          return;
+     
+      if (compositor.visible &&
+         (!filterByWorkspace || windowIsOnWorkspace(metaWindow, activeWorkspace)) &&
+         (!desktopOnly || metaWindow.get_window_type() === Meta.WindowType.DESKTOP) &&
+          metaWindow.get_window_type() !== Meta.WindowType.OVERRIDE_OTHER /*&& metaWindow.get_wm_class() !== "Nemo-desktop"*/) {
+        
+          let winRect = metaWindow.get_buffer_rect();
+          let winX = winRect.x;
+          let winY = winRect.y;
+          let winX2 = winRect.x + winRect.width;
+          let winY2 = winRect.y + winRect.height;
+          if (rectOverlap(winX, winY, winX2, winY2, blurX, blurY, blurX2, blurY2)) {
+              windowsToClone.push(metaWindow);
+          }
       }
    });
 
@@ -673,6 +722,21 @@ class CloneManager {
       delete background._blurCinnamonDesktopOnly;
       this._backgrounds.splice(idx, 1);
       debugMsg( `Removed background for "${background}"/"${background._blurCinnamonName}", group children = ${background._blurCinnamonGroup.get_n_children()}` );
+   }
+
+   refreshBackground(background, clearFirst = false) {
+       if (!background)
+           return;
+       let idx = this._backgrounds.indexOf(background);
+       if (idx === -1)
+           return;
+       if (clearFirst && background._blurCinnamonWinClones) {
+           destroyAllWindowsClones(background);
+       }
+       cloneWindowsForBackground(
+           background,
+           background._blurCinnamonDesktopOnly
+       );
    }
 
    isDynamicEffectActive(background) {
@@ -847,17 +911,26 @@ class CloneManager {
    }
 
    _updateCurrentWorkspace() {
-      let currentWs = global.workspace_manager.get_active_workspace_index();
-      if (currentWs !== this._activeWorkspaceIdx) {
-         this._activeWorkspaceIdx = currentWs;
-         // After switching workspace, if a window with a blurred background is dragged off a
-         // dynamic blurred panel the window will not get drawn correctly after it's clone is deleted
-         // from the panels dynamic blur group. This reapplyEffect call is a workaround for this issue.
-         debugMsg( `Reapplying application window effects after workspace switch from ${this._activeWorkspaceIdx} to ${currentWs}` );
-         if (blurApplications) {
-            blurApplications.reapplyEffects();
-         }
-      }
+       let currentWs = global.workspace_manager.get_active_workspace_index();
+       if (currentWs === this._activeWorkspaceIdx)
+           return;
+       let previousWs = this._activeWorkspaceIdx;
+       this._activeWorkspaceIdx = currentWs;
+       debugMsg(`Workspace changed from ${previousWs} to ${currentWs}`);
+   
+       /*
+        * Remove OSD backgrounds clones synchronously so that there cannot be even one
+        * frame containing the previous workspace, then rebuild them
+        * on idle when Cinnamon has updated the workspace state.
+        */
+       this._backgrounds.forEach(background => {
+           if (background._blurCinnamonName === "OsdWindow") {
+               this.refreshBackground(background, true);
+           }
+       });
+       if (blurApplications) {
+           blurApplications.reapplyEffects();
+       }
    }
 
    // The metaWindow has moved, so we need to move it's clones.
@@ -1285,7 +1358,7 @@ class BlurOSD extends BlurBase {
    _show(...params) {
       let ret = blurOSDThis.original_show.call(this, ...params);
       if (settings.osdSliderEffects) {
-         try { blurOSDThis._showBackground(this, this._hbox || (this.actor ? this.actor.get_first_child() : null)); } catch (e) { global.logError(e); }
+         try { blurOSDThis._showBackground(this, this._hbox || (this.actor ? this.actor.get_first_child() : null), false); } catch (e) { global.logError(e); }
       }
       return ret;
    }
@@ -1303,7 +1376,7 @@ class BlurOSD extends BlurBase {
    _display(...params) {
       let ret = blurOSDThis.original_display.call(this, ...params);
       if (settings.osdWorkspaceEffects) {
-         try { blurOSDThis._showBackground(this, this._vbox || (this.actor ? this.actor.get_first_child() : null)); } catch (e) { global.logError(e); }
+         try { blurOSDThis._showBackground(this, this._vbox || (this.actor ? this.actor.get_first_child() : null), true); } catch (e) { global.logError(e); }
       }
       return ret;
    }
@@ -1316,7 +1389,7 @@ class BlurOSD extends BlurBase {
    _infoOSD_show(...params) {
       let ret = blurOSDThis.original_infoOSD_show.call(this, ...params);
       if (settings.osdWorkspaceEffects) {
-         try { blurOSDThis._showBackground(this, this.actor ? this.actor.get_first_child() : null); } catch (e) { global.logError(e); }
+         try { blurOSDThis._showBackground(this, this.actor ? this.actor.get_first_child() : null, true); } catch (e) { global.logError(e); }
       }
       return ret;
    }
@@ -1326,79 +1399,176 @@ class BlurOSD extends BlurBase {
       return blurOSDThis.original_infoOSD_hide.call(this, ...params);
    }
 
-   _showBackground(osd, actor) {
-      if (actor && !osd._blurCinnamonBackground) {
-         if (this._background) {
-            this._hideBackground(this._currentOsd, this._currentActor);
-         }
+   _scheduleReclip(actor, showBackground = false) {
+      if (!actor || !this._background)
+         return;
+   
+      if (this._idleId) {
+         Mainloop.source_remove(this._idleId);
+         this._idleId = null;
+      }
+   
+      if (this._reclipIdleId) {
+         Mainloop.source_remove(this._reclipIdleId);
+         this._reclipIdleId = null;
+      }
+   
+      let background = this._background;
+   
+      this._idleId = Mainloop.idle_add(() => {
+        this._idleId = null;
+
+        if (this._background !== background) return false;
+   
+        this._setClip(actor);
+        if (showBackground) background.show();
+   
+        // Re-clip on the next idle cycle to catch layout shifts
+        // after the first layout/paint cycle
+        this._reclipIdleId = Mainloop.idle_add(() => {
+            this._reclipIdleId = null;
+            if (this._background === background) {
+               this._setClip(actor);
+            }
+            return false;
+         });
+         return false;
+      });
+   }
+
+   _showBackground(osd, actor, isWorkspaceOsd = false) {
+      if (!actor)
+         return;
+      
+      if (osd._blurCinnamonBackground &&
+          osd._blurCinnamonBackground === this._background) {
+   
          this._currentOsd = osd;
          this._currentActor = actor;
 
-         if (!actor._blurCinnamonData && settings.allowTransparentColorOSD) {
-            actor._blurCinnamonData = { original_color: actor.get_background_color(), original_style: actor.get_style(),
-                                      original_class: actor.get_style_class_name(), original_pseudo_class: actor.get_style_pseudo_class() };
-            actor.set_style( "background-gradient-direction: vertical; background-gradient-start: transparent; " +
-                             "background-gradient-end: transparent; background: transparent;" );
-         } else if (!settings.allowTransparentColorOSD && actor._blurCinnamonData) { 
-            actor.set_background_color(actor._blurCinnamonData.original_color);
-            actor.set_style(actor._blurCinnamonData.original_style);
-            actor.set_style_class_name(actor._blurCinnamonData.original_class);
-            actor.set_style_pseudo_class(actor._blurCinnamonData.original_pseudo_class);
-            delete actor._blurCinnamonData;
+         if (!isWorkspaceOsd)
+            return;
+        
+         // Workspace OSD needs an explicit refresh because its visual
+         // source changes when switching workspaces
+         this._scheduleReclip(actor, true);
+   
+         if ((this._blurType === BlurType.DynamicBlur ||
+              this._blurType === BlurType.DynamicMC ||
+              this._blurType === BlurType.DynamicDK) &&
+             cloneManager) {
+   
+            cloneManager.refreshBackground(this._background, true);
          }
-
-         let [opacity, blendColor, blurType, radius, saturation] = this._getSettings(settings.osdOverride);
-         this._blurType = blurType;
-         
-         this._background = this._createBackgroundAndEffects(opacity, blendColor, blurType, radius, saturation, global.overlay_group, 10);
-         this._background._blurCinnamonName = "OsdWindow";
-         osd._blurCinnamonBackground = this._background;
-
-         if (blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC || blurType === BlurType.DynamicDK) {
-            this._createDynamicEffect(this._background);
-         }
-         
-         let themeNode = actor.get_theme_node();
-         if (themeNode) {
-           let corner_radius = themeNode.get_border_radius(St.Corner.TOPLEFT);
-           if (corner_radius === 9999) { corner_radius = actor.height / 2; }
-           
-           this._updateCornerRadius(this._background, (corner_radius)/global.ui_scale);
-         }
-         
-         if (osd.actor) {
-             this._signalManager.connect(osd.actor, "notify::allocation", () => this._setClip(actor) );
-         }
-         this._signalManager.connect(actor, "notify::allocation", () => this._setClip(actor) );
-
-         if (this._idleId) {
-             Mainloop.source_remove(this._idleId);
-             this._idleId = null;
-         }
-         
-         this._idleId = Mainloop.idle_add(() => {
-             if (this._background) {
-                 this._setClip(actor);
-                 this._background.show();
-
-                 // Re-clip on the next idle cycle to catch layout shifts after the first paint
-                 Mainloop.idle_add(() => {
-                     if (this._background) this._setClip(actor);
-                 });
-             }
-             this._idleId = null;
-         });
-
-         this._setClip(actor);
+   
+         return;
       }
+   
+      // Stale marker from a background that has already gone away
+      if (osd._blurCinnamonBackground &&
+          osd._blurCinnamonBackground !== this._background) {
+         delete osd._blurCinnamonBackground;
+      }
+   
+      if (this._background) {
+         this._hideBackground(this._currentOsd, this._currentActor);
+      }
+   
+      this._currentOsd = osd;
+      this._currentActor = actor;
+   
+      if (!actor._blurCinnamonData && settings.allowTransparentColorOSD) {
+         actor._blurCinnamonData = {
+            original_color: actor.get_background_color(),
+            original_style: actor.get_style(),
+            original_class: actor.get_style_class_name(),
+            original_pseudo_class: actor.get_style_pseudo_class()
+         };
+   
+         actor.set_style(
+            "background-gradient-direction: vertical; " +
+            "background-gradient-start: transparent; " +
+            "background-gradient-end: transparent; " +
+            "background: transparent;"
+         );
+   
+      } else if (!settings.allowTransparentColorOSD &&
+                 actor._blurCinnamonData) {
+   
+         actor.set_background_color(actor._blurCinnamonData.original_color);
+         actor.set_style(actor._blurCinnamonData.original_style);
+         actor.set_style_class_name(actor._blurCinnamonData.original_class);
+         actor.set_style_pseudo_class(
+            actor._blurCinnamonData.original_pseudo_class
+         );
+   
+         delete actor._blurCinnamonData;
+      }
+   
+      let [opacity, blendColor, blurType, radius, saturation] =
+         this._getSettings(settings.osdOverride);
+   
+      this._blurType = blurType;
+   
+      this._background = this._createBackgroundAndEffects(
+         opacity,
+         blendColor,
+         blurType,
+         radius,
+         saturation,
+         global.overlay_group,
+         10
+      );
+   
+      this._background._blurCinnamonName = "OsdWindow";
+      osd._blurCinnamonBackground = this._background;
+   
+      if (blurType === BlurType.DynamicBlur ||
+          blurType === BlurType.DynamicMC ||
+          blurType === BlurType.DynamicDK) {
+         this._createDynamicEffect(this._background);
+      }
+   
+      let themeNode = actor.get_theme_node();
+   
+      if (themeNode) {
+         let corner_radius =
+            themeNode.get_border_radius(St.Corner.TOPLEFT);
+   
+         if (corner_radius === 9999) {
+            corner_radius = actor.height / 2;
+         }
+   
+         this._updateCornerRadius(this._background, corner_radius / global.ui_scale);
+      }
+   
+      if (osd.actor) {
+         this._signalManager.connect(osd.actor, "notify::allocation", () => this._setClip(actor));
+      }
+   
+      this._signalManager.connect(actor, "notify::allocation", () => this._setClip(actor));
+   
+      this._setClip(actor);
+      this._scheduleReclip(actor, true);
    }
 
    _hideBackground(osd, actor) {
       if (!this._background) return;
-      
+     
+      // Ignore a stale hide callback from an OSD that no longer owns
+      // the active BlurOSD background
+      if (osd && this._currentOsd && osd !== this._currentOsd) {
+         return;
+      }
+     
       if (this._idleId) {
-          Mainloop.source_remove(this._idleId);
-          this._idleId = null;
+         Mainloop.source_remove(this._idleId);
+         this._idleId = null;
+      }
+      
+      if (this._reclipIdleId) {
+         Mainloop.source_remove(this._reclipIdleId);
+         this._reclipIdleId = null;
       }
       
       if (this._blurType === BlurType.DynamicBlur || this._blurType === BlurType.DynamicMC || this._blurType === BlurType.DynamicDK) {
@@ -1421,7 +1591,7 @@ class BlurOSD extends BlurBase {
       }
       super.destroy(this._background);
       this._background.destroy();
-      delete this._background;
+      this._background = null;
       if (osd) delete osd._blurCinnamonBackground;
      
       this._currentOsd = null;
@@ -1432,10 +1602,10 @@ class BlurOSD extends BlurBase {
       if (!actor || !this._background) return;
       
       let [x, y] = actor.get_transformed_position();
-      let [scale_x, scale_y] = actor.get_scale(); // Get the scale of the actor
+      let [scale_x, scale_y] = actor.get_scale(); 
       let width = actor.width * scale_x;
       let height = actor.height * scale_y;
-
+      
       let cornerEffect = this._getCornerEffect(this._background);
       if (cornerEffect) {
          cornerEffect.clip = [
@@ -1459,6 +1629,11 @@ class BlurOSD extends BlurBase {
       if (this._idleId) {
          Mainloop.source_remove(this._idleId);
          this._idleId = null;
+      }
+
+      if (this._reclipIdleId) {
+         Mainloop.source_remove(this._reclipIdleId);
+         this._reclipIdleId = null;
       }
 
       if (this._signalManager) this._signalManager.disconnectAllSignals();

--- a/BlurCinnamon@klangman/6.0/extension.js
+++ b/BlurCinnamon@klangman/6.0/extension.js
@@ -1429,6 +1429,7 @@ class BlurOSD extends BlurBase {
       }
    
       let background = this._background;
+      let viewport = this._viewport;
    
       this._idleId = Mainloop.idle_add(() => {
         this._idleId = null;
@@ -1437,6 +1438,7 @@ class BlurOSD extends BlurBase {
    
         this._setClip(actor);
         if (showBackground) background.show();
+        if (viewport && this._viewport === viewport) viewport.show();   
         // Re-clip on the next idle cycle to catch layout shifts
         // after the first layout/paint cycle
         this._reclipIdleId = Mainloop.idle_add(() => {
@@ -1453,16 +1455,15 @@ class BlurOSD extends BlurBase {
    _showBackground(osd, actor, isWorkspaceOsd = false, clipActor = actor) {
       if (!actor)
          return;
-      
-      if (osd._blurCinnamonBackground &&
-          osd._blurCinnamonBackground === this._background) {
+   
+      if (osd._blurCinnamonBackground && osd._blurCinnamonBackground === this._background) {
    
          this._currentOsd = osd;
          this._currentActor = actor;
-
+   
          if (!isWorkspaceOsd)
             return;
-        
+   
          // Workspace OSD needs an explicit refresh because its visual
          // source changes when switching workspaces
          this._scheduleReclip(clipActor, true);
@@ -1479,8 +1480,7 @@ class BlurOSD extends BlurBase {
       }
    
       // Stale marker from a background that has already gone away
-      if (osd._blurCinnamonBackground &&
-          osd._blurCinnamonBackground !== this._background) {
+      if (osd._blurCinnamonBackground && osd._blurCinnamonBackground !== this._background) {
          delete osd._blurCinnamonBackground;
       }
    
@@ -1496,7 +1496,8 @@ class BlurOSD extends BlurBase {
             original_color: actor.get_background_color(),
             original_style: actor.get_style(),
             original_class: actor.get_style_class_name(),
-            original_pseudo_class: actor.get_style_pseudo_class()
+            original_pseudo_class:
+               actor.get_style_pseudo_class()
          };
    
          actor.set_style(
@@ -1505,44 +1506,40 @@ class BlurOSD extends BlurBase {
             "background-gradient-end: transparent; " +
             "background: transparent;"
          );
-   
-      } else if (!settings.allowTransparentColorOSD &&
-                 actor._blurCinnamonData) {
-   
+      } else if (!settings.allowTransparentColorOSD && actor._blurCinnamonData) {
          actor.set_background_color(actor._blurCinnamonData.original_color);
          actor.set_style(actor._blurCinnamonData.original_style);
          actor.set_style_class_name(actor._blurCinnamonData.original_class);
-         actor.set_style_pseudo_class(
-            actor._blurCinnamonData.original_pseudo_class
-         );
-   
+         actor.set_style_pseudo_class(actor._blurCinnamonData.original_pseudo_class);
          delete actor._blurCinnamonData;
       }
    
       let [opacity, blendColor, blurType, radius, saturation] = this._getSettings(settings.osdOverride);
-   
       this._blurType = blurType;
-   
-      this._background = this._createBackgroundAndEffects(opacity, blendColor, blurType, radius, saturation, global.overlay_group, 10);
-   
+      let useViewport = this._wantsViewport(blurType);
+
+      this._background = this._createBackgroundAndEffects(opacity, blendColor, blurType, radius, saturation, global.overlay_group, 10, true, true, useViewport);
       this._background._blurCinnamonName = "OsdWindow";
+      this._viewport = this._background._blurCinnamonViewport;
+      if (this._viewport) this._viewport._blurCinnamonName = "OsdWindow";
       osd._blurCinnamonBackground = this._background;
-   
+
       if (blurType === BlurType.DynamicBlur ||
           blurType === BlurType.DynamicMC ||
           blurType === BlurType.DynamicDK) {
+   
          this._createDynamicEffect(this._background);
       }
    
+      // Use the actor that represents the complete popup for
+      // both clipping geometry and corner radius
       let radiusActor = clipActor || actor;
       let themeNode = radiusActor.get_theme_node();
    
       if (themeNode) {
          let corner_radius = themeNode.get_border_radius(St.Corner.TOPLEFT);
-         if (corner_radius === 9999) {
-            corner_radius = Math.min(radiusActor.width, radiusActor.height) / 2;
-         }
-         this._updateCornerRadius(this._background, corner_radius / global.ui_scale);
+         if (corner_radius === 9999) { corner_radius = Math.min(radiusActor.width, radiusActor.height) / 2; }
+         this._updateViewportCornerRadius(this._background, this._viewport, (corner_radius)/global.ui_scale, true, true);
       }
    
       if (osd.actor && osd.actor !== clipActor) {


### PR DESCRIPTION
Hello, @klangman,
I've been working over the past few days on fixing the blur effect on the OSD pop-ups, which was still not behaving correctly. I believe the main issues are now resolved, and I've also tested the changes on Cinnamon 6.0.5 inside a virtual machine.
The main changes are listed below:
- Fix blur clipping and sizing for workspace and volume OSDs on older Cinnamon versions.
- Handle legacy and modern OSD actor layouts separately.
- Improve workspace OSD background refresh when switching workspaces.
- Stabilize OSD clipping with delayed re-clipping.
- Improve cleanup of OSD backgrounds, signals, timers, and related references.
- Preserve the existing behavior on recent Cinnamon versions while extending compatibility with older releases.

Please let me know if you have any feedback or suggestions on the changes.

I'm seeing here in the PR, that there are a few merge conflicts, I'll resolve the conflicts locally and do a commit in my repo adding your changes.